### PR TITLE
Add compatibility with MapAtlases - only affects LecternAnimation

### DIFF
--- a/src/client/java/fr/madu59/fwa/anims/LecternAnimation.java
+++ b/src/client/java/fr/madu59/fwa/anims/LecternAnimation.java
@@ -19,20 +19,121 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.BlockAndLightGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity; 
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
-public class LecternAnimation extends Animation{
-    
+public class LecternAnimation extends Animation {
+
+    // -----------------------------------------------------------------------
+    // Constants
+    // -----------------------------------------------------------------------
+
+    // DEFAULT TEXTURE FOR BOOKS
+    private static final Identifier DEFAULT_BOOK_TEXTURE =
+            Identifier.tryParse("minecraft:textures/entity/enchantment/enchanting_table_book.png");
+
+    // ATLAS TEXTURE BASED ON DIMENSION, EXCLUSIVE TO THE ATLAS
+    private static final Identifier ATLAS_TEXTURE_OVERWORLD =
+            Identifier.tryParse("map_atlases:textures/entity/lectern_atlas.png");
+    private static final Identifier ATLAS_TEXTURE_NETHER =
+            Identifier.tryParse("map_atlases:textures/entity/lectern_atlas_nether.png");
+    private static final Identifier ATLAS_TEXTURE_END =
+            Identifier.tryParse("map_atlases:textures/entity/lectern_atlas_end.png");
+    private static final Identifier ATLAS_TEXTURE_OTHER =
+            Identifier.tryParse("map_atlases:textures/entity/lectern_atlas_unknown.png");
+
+    // -----------------------------------------------------------------------
+    // Fields
+    // -----------------------------------------------------------------------
+
     private final BookModel bookModel;
     private final float hash;
-    private final Identifier textureId = Identifier.tryParse("minecraft:textures/entity/enchantment/enchanting_table_book.png");
 
-    public LecternAnimation(BlockPos position, double startTick, boolean oldIsOpen, boolean newIsOpen, BlockState oldState, BlockState newState) {
+    /**
+     * Resolved once at construction time and never changed again.
+     * Holds the texture that should be rendered for the book on this lectern.
+     * Defaults to the vanilla enchanting-table book texture; switches to the
+     * appropriate atlas texture when Map Atlases is present and the block
+     * entity reports that it contains an atlas.
+     */
+    private final Identifier textureId;
+
+    // -----------------------------------------------------------------------
+    // Constructor
+    // -----------------------------------------------------------------------
+
+    public LecternAnimation(BlockPos position, double startTick,
+                            boolean oldIsOpen, boolean newIsOpen,
+                            BlockState oldState, BlockState newState) {
         super(position, startTick, oldIsOpen, newIsOpen, oldState, newState);
-        this.bookModel = new BookModel(Minecraft.getInstance().getEntityModels().bakeLayer(ModelLayers.BOOK));
+        this.bookModel = new BookModel(
+                Minecraft.getInstance().getEntityModels().bakeLayer(ModelLayers.BOOK));
         this.hash = position.hashCode();
+        this.textureId = resolveTexture(position);
     }
+
+    // -----------------------------------------------------------------------
+    // Texture resolution (soft dependency on Map Atlases)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Checks whether the lectern at {pos} holds a Map Atlas item.
+     * The check is done purely through the {AtlasLectern} interface that
+     * Map Atlases injects via mixin, so this code path is only active when that
+     * mod is loaded. No hard compile-time dependency is introduced; the cast is
+     * guarded by a try/catch so that a missing class simply falls through to the
+     * default texture.
+     */
+    private static Identifier resolveTexture(BlockPos pos) {
+        try {
+            Level level = Minecraft.getInstance().level;
+            if (level == null) return DEFAULT_BOOK_TEXTURE;
+
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be == null) return DEFAULT_BOOK_TEXTURE;
+
+            // pepjebs.mapatlases.utils.AtlasLectern is injected onto
+            // LecternBlockEntity by Map Atlases at runtime via mixin.
+            // We load the interface reflectively so this class compiles and
+            // runs fine even when Map Atlases is absent.
+            Class<?> atlasLecternClass =
+                    Class.forName("pepjebs.mapatlases.utils.AtlasLectern");
+
+            if (!atlasLecternClass.isInstance(be)) return DEFAULT_BOOK_TEXTURE;
+
+            // hasAtlas() — defined in the AtlasLectern interface
+            boolean hasAtlas = (boolean)
+                    atlasLecternClass.getMethod("mapatlases$hasAtlas").invoke(be);
+
+            if (!hasAtlas) return DEFAULT_BOOK_TEXTURE;
+
+            return getDimensionAtlasTexture(level);
+
+        } catch (ClassNotFoundException ignored) {
+            // Map Atlases is not installed — perfectly normal
+            return DEFAULT_BOOK_TEXTURE;
+        } catch (Exception e) {
+            // Something changed in Map Atlases' API; degrade gracefully
+            return DEFAULT_BOOK_TEXTURE;
+        }
+    }
+
+    /**
+     * Apply Atlas texture based on dimension
+     */
+    private static Identifier getDimensionAtlasTexture(Level level) {
+        var dimension = level.dimension();
+        if (dimension == Level.OVERWORLD) return ATLAS_TEXTURE_OVERWORLD;
+        if (dimension == Level.NETHER)    return ATLAS_TEXTURE_NETHER;
+        if (dimension == Level.END)       return ATLAS_TEXTURE_END;
+        return ATLAS_TEXTURE_OTHER;
+    }
+
+    // -----------------------------------------------------------------------
+    // Animation contract
+    // -----------------------------------------------------------------------
 
     @Override
     public double getAnimDuration() {


### PR DESCRIPTION
Hey! I added compatibility with the Map Atlases mod I just ported to 26.1 :)

I tested it and it’s a soft dependency:

- No change to the book/lectern when the mod isn’t installed
- No impact on the default book/lectern behaviour with the mod installed

This is a very small change, it only dynamically adjusts the texture in LecternAnimation when Atlases are present.

Tested both with and without the mod, everything behaves as expected!