### PR TITLE
Add a swing driver hook for lanterns and chains

### DIFF
--- a/src/client/java/fr/madu59/fwa/anims/ChainAnimation.java
+++ b/src/client/java/fr/madu59/fwa/anims/ChainAnimation.java
@@ -8,6 +8,8 @@ import org.joml.Quaternionf;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import fr.madu59.fwa.FancyWorldAnimationsClient;
+import fr.madu59.fwa.api.animations.HangingSwing;
+import fr.madu59.fwa.api.animations.SwingDrivers;
 import fr.madu59.fwa.config.SettingsManager;
 import fr.madu59.fwa.rendering.AnimationRenderingContext;
 import fr.madu59.fwa.rendering.RenderHelper;
@@ -30,6 +32,7 @@ public class ChainAnimation extends Animation{
     private float tiltX = 0f;
     private float tiltZ = 0f;
     private float spin = 0f;
+    private final HangingSwing swing = new HangingSwing();
     private int chainCount = 0;
     private final List<BlockStateModelPart> parts = new ArrayList<>();
     private BlockStateModel model;
@@ -139,6 +142,13 @@ public class ChainAnimation extends Animation{
     }
 
     public void animate(AnimationRenderingContext context) {
+        if(SwingDrivers.getSwing(position, context.getNowTick(), swing)){
+            this.tiltX = swing.tiltX;
+            this.tiltZ = swing.tiltZ;
+            this.spin = swing.spin;
+            return;
+        }
+
         float posOffset = (position.getX() * 0.6f) + (position.getZ() * 0.6f);
         float uniqueTime = ((float)context.getNowTick()) * 0.1f + posOffset;
 

--- a/src/client/java/fr/madu59/fwa/anims/ChainAnimation.java
+++ b/src/client/java/fr/madu59/fwa/anims/ChainAnimation.java
@@ -142,7 +142,7 @@ public class ChainAnimation extends Animation{
     }
 
     public void animate(AnimationRenderingContext context) {
-        if(SwingDrivers.getSwing(position, context.getNowTick(), swing)){
+        if(SwingDrivers.getSwing(position, defaultState, context.getNowTick(), swing)){
             this.tiltX = swing.tiltX;
             this.tiltZ = swing.tiltZ;
             this.spin = swing.spin;

--- a/src/client/java/fr/madu59/fwa/anims/LanternAnimation.java
+++ b/src/client/java/fr/madu59/fwa/anims/LanternAnimation.java
@@ -7,6 +7,8 @@ import org.joml.Quaternionf;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 
+import fr.madu59.fwa.api.animations.HangingSwing;
+import fr.madu59.fwa.api.animations.SwingDrivers;
 import fr.madu59.fwa.compat.ModCompat;
 import fr.madu59.fwa.config.SettingsManager;
 import fr.madu59.fwa.rendering.AnimationRenderingContext;
@@ -31,6 +33,7 @@ public class LanternAnimation extends Animation{
     private float tiltX = 0f;
     private float tiltZ = 0f;
     private float spin = 0f;
+    private final HangingSwing swing = new HangingSwing();
     private final List<BlockStateModelPart> parts = new ArrayList<>();
     private int chainCount;
     private final List<BlockStateModelPart> chainParts = new ArrayList<>();
@@ -144,6 +147,13 @@ public class LanternAnimation extends Animation{
     }
 
     public void animate(AnimationRenderingContext context) {
+        if(SwingDrivers.getSwing(position, context.getNowTick(), swing)){
+            this.tiltX = swing.tiltX;
+            this.tiltZ = swing.tiltZ;
+            this.spin = swing.spin;
+            return;
+        }
+
         float posOffset = (position.getX() * 0.6f) + (position.getZ() * 0.6f);
         float uniqueTime = ((float)context.getNowTick()) * 0.1f + posOffset;
 

--- a/src/client/java/fr/madu59/fwa/anims/LanternAnimation.java
+++ b/src/client/java/fr/madu59/fwa/anims/LanternAnimation.java
@@ -147,7 +147,7 @@ public class LanternAnimation extends Animation{
     }
 
     public void animate(AnimationRenderingContext context) {
-        if(SwingDrivers.getSwing(position, context.getNowTick(), swing)){
+        if(SwingDrivers.getSwing(position, defaultState, context.getNowTick(), swing)){
             this.tiltX = swing.tiltX;
             this.tiltZ = swing.tiltZ;
             this.spin = swing.spin;

--- a/src/client/java/fr/madu59/fwa/api/animations/HangingSwing.java
+++ b/src/client/java/fr/madu59/fwa/api/animations/HangingSwing.java
@@ -1,0 +1,20 @@
+package fr.madu59.fwa.api.animations;
+
+/*
+ * HangingSwing class carries the swing of a hanging block in degrees. Cleared before each
+ * call, so any field the driver leaves alone is zero.
+ */
+public class HangingSwing {
+
+    public float tiltX;
+
+    public float tiltZ;
+
+    public float spin;
+
+    public void set(float tiltX, float tiltZ, float spin){
+        this.tiltX = tiltX;
+        this.tiltZ = tiltZ;
+        this.spin = spin;
+    }
+}

--- a/src/client/java/fr/madu59/fwa/api/animations/SwingDriver.java
+++ b/src/client/java/fr/madu59/fwa/api/animations/SwingDriver.java
@@ -1,0 +1,14 @@
+package fr.madu59.fwa.api.animations;
+
+import net.minecraft.core.BlockPos;
+
+/*
+ * SwingDriver interface supplies the swing of lanterns and chains, replacing the idle
+ * animation. Called once per block per rendered frame, including the shadow pass, so it must
+ * return the same swing for a given position and tick instead of advancing its own sim.
+ */
+@FunctionalInterface
+public interface SwingDriver {
+
+    boolean getSwing(BlockPos position, double nowTick, HangingSwing swing);
+}

--- a/src/client/java/fr/madu59/fwa/api/animations/SwingDriver.java
+++ b/src/client/java/fr/madu59/fwa/api/animations/SwingDriver.java
@@ -1,6 +1,7 @@
 package fr.madu59.fwa.api.animations;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
 
 /*
  * SwingDriver interface supplies the swing of lanterns and chains, replacing the idle
@@ -10,5 +11,5 @@ import net.minecraft.core.BlockPos;
 @FunctionalInterface
 public interface SwingDriver {
 
-    boolean getSwing(BlockPos position, double nowTick, HangingSwing swing);
+    boolean getSwing(BlockPos position, BlockState state, double nowTick, HangingSwing swing);
 }

--- a/src/client/java/fr/madu59/fwa/api/animations/SwingDrivers.java
+++ b/src/client/java/fr/madu59/fwa/api/animations/SwingDrivers.java
@@ -3,6 +3,7 @@ package fr.madu59.fwa.api.animations;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
 
 public class SwingDrivers {
 
@@ -21,9 +22,9 @@ public class SwingDrivers {
     }
 
     @ApiStatus.Internal
-    public static boolean getSwing(BlockPos position, double nowTick, HangingSwing swing){
+    public static boolean getSwing(BlockPos position, BlockState state, double nowTick, HangingSwing swing){
         if(driver == null) return false;
         swing.set(0f, 0f, 0f);
-        return driver.getSwing(position, nowTick, swing);
+        return driver.getSwing(position, state, nowTick, swing);
     }
 }

--- a/src/client/java/fr/madu59/fwa/api/animations/SwingDrivers.java
+++ b/src/client/java/fr/madu59/fwa/api/animations/SwingDrivers.java
@@ -1,0 +1,29 @@
+package fr.madu59.fwa.api.animations;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.core.BlockPos;
+
+public class SwingDrivers {
+
+    private static SwingDriver driver = null;
+
+    public static void register(SwingDriver swingDriver){
+        driver = swingDriver;
+    }
+
+    public static void unregister(){
+        driver = null;
+    }
+
+    public static SwingDriver getDriver(){
+        return driver;
+    }
+
+    @ApiStatus.Internal
+    public static boolean getSwing(BlockPos position, double nowTick, HangingSwing swing){
+        if(driver == null) return false;
+        swing.set(0f, 0f, 0f);
+        return driver.getSwing(position, nowTick, swing);
+    }
+}


### PR DESCRIPTION
Lets a mod supply the swing of hanging blocks in place of the built in idle motion, so an external provider can steer it.
A 1.21.11 interface would be ideal as well. I'm willing to get that written up as well if you are open to that :)
